### PR TITLE
Adds npm to the list of packages to install.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -6,10 +6,10 @@ hackerspace membership server for sudoroom
 
 > _This application is known to work with version `0.10.21` of `node`. There is an issue with the `canvas` module, but once it is updated you should be able to run with version `0.12` of `node`._
 
-Install [node](https://nodejs.org) and `libcairo2-dev`:
+Install [node](https://nodejs.org), [npm](https://nodejs.org/) and [Cairo](http://cairographics.org/) development files.
 
 ```
-$ sudo apt-get install nodejs libcairo2-dev
+$ sudo apt-get install nodejs npm libcairo2-dev
 $ sudo ln -s `which nodejs` /usr/local/bin/node
 ```
 


### PR DESCRIPTION
I was getting started looking at sudo-humans and noticed that npm doesn't get installed automatically with nodejs, but it's required to follow the instructions in the readme. So I figured I'd improve the readme a little.
