### PR TITLE
CTA to set up membership

### DIFF
--- a/static/collective.html
+++ b/static/collective.html
@@ -1,6 +1,8 @@
 <div id="main">
   <p class="msg">
     We are the humans of <span key="collective"></span>. <a key="admin-link" href=""></a>
+    <br />
+    <a key="collective-membership-link"></a>
   </p>
 
   <div class="actions clearfix">
@@ -41,7 +43,7 @@
       <div class="name" key="name"></div>
     </button></a>
   </div>
- 
+
   <div class="comrades hbar">
     <h2 class="title">comrades</h2>
     <a template="comrade" key="link"><button class="hitem member">


### PR DESCRIPTION
Added link to collective page that sends user to edit profile or edit membership pages. 

Resolves #71

Notes:
- `leveldown` package consistently fails the `node-gyp rebuild` command during install, had to rev to later version to setup repo locally. Seems to be a [known issue](https://github.com/Level/leveldown/issues/244) for older versions of the package
- Still digging around to clarify when a user has an active membership to a collective, since in that case it's not as imperative to message this information (and at the very least, could resolve language from "Setup or edit" to one or the other)
- Administrate collective link seems to always show up, both locally and on sudo-humans