### PR TITLE
Payment fixes/etc

### DIFF
--- a/routes/payment.js
+++ b/routes/payment.js
@@ -39,7 +39,6 @@ module.exports = function (users, auth, blob, settings) {
         var input = through(), output = through();
         users.get(m.session.data.id, function (err, user) {
             if (err) return m.error(err);
-
             var collective = m.params.collective;
 
             if (!user.collectives[collective]) {
@@ -208,9 +207,11 @@ module.exports = function (users, auth, blob, settings) {
                             return m.error(500, err);
                         }
 
+
                         userStripe.customer_id = customer.id;
 
                         createOrUpdateSubscription(stripe, user, userStripe, null, m, function(err, subscription) {
+                          console.log(err);
                             if(err) {return m.error(500, err)}
                             console.log("created: ", subscription);
                             userStripe.last_two_digits = m.params.lastTwoDigits;
@@ -277,7 +278,14 @@ module.exports = function (users, auth, blob, settings) {
             stripe.customers.createSubscription(
                 userStripe.customer_id, {
                 plan: m.params.subscription_plan,
-                source: m.params.stripeToken
+                source: {
+                  object: 'card',
+                  exp_month: m.params.exp_month,
+                  exp_year: m.params.exp_year,
+                  number: m.params.card_number,
+                  cvc: m.params.cvc,
+                  name: m.params.name
+                }
             }, callback);
         }
     }


### PR DESCRIPTION
Started to read through and test the payments flow tonight. I notice without Stripe key, server crashes and burns on the payment page. Now it produces a 500, but if you use the wrong key (as opposed to undefined) it still crashes and burns in a different place. Probably an adjacent error to #59 with similar fix? 

Second commit might be a bit more necessary. Could not make a test subscription (test key + fake card) without this change to the API, passing in card details. Otherwise Stripe complains that the customer does not have an attached payment source. Most likely subscriptions aren't broken since I myself created a subscription earlier this year, and that code hasn't radically been altered since last June. But we should look into why it's failing in this scenario regardless, I'll poke around more