### PR TITLE
Remove NPM upgrade task from Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && apt-get install -y \
   nodejs \
   nodejs-legacy \
   npm
-# Upgrading npm allegedly works around the REPLACE_INVALID_UTF8 issue
-RUN npm -g install npm
 # Put the app in here
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Apparently running `apt-get install npm` already installs the required NPM version 1.4.21.
Running `npm install npm` now upgrades NPM to version 4.6.1 and this breaks things.

Things 'patch' removes the two lines related to the NPM upgrade (that shouldn't happen) from the Dockerfile.